### PR TITLE
Use llama.cpp directory path as the download path

### DIFF
--- a/ggify.py
+++ b/ggify.py
@@ -292,7 +292,7 @@ def main():
     if args.llama_cpp_dir:
         os.environ["LLAMA_CPP_DIR"] = args.llama_cpp_dir
     repo = args.repo
-    dirname = os.path.join(".", "models", repo.replace("/", "__"))
+    dirname = os.path.join(get_llama_cpp_dir(), "models", repo.replace("/", "__"))
     download_repo(repo, dirname)
     types = set(re.split(r",\s*", args.types))
     output_paths = list(


### PR DESCRIPTION
The converter should be able to find the right model path. Just changing the download path is definitely still inflexible - if you want to support an external converter, I can add some more command line options here.